### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10
+FROM node:4.2
 
 WORKDIR /home/slackin
 COPY startslackin /home/slackin/


### PR DESCRIPTION
The latest version of slackin wants node >=0.12.0. Node 4.2.2 is the latest LTS, so settling for this.
